### PR TITLE
chore: upgrade to Zig 0.16

### DIFF
--- a/src/counter.zig
+++ b/src/counter.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const lock_impl = @import("lock.zig");
 const Allocator = std.mem.Allocator;
 
 const m = @import("metric.zig");
@@ -130,7 +131,7 @@ pub fn CounterVec(comptime V: type, comptime L: type) type {
             vec: MetricVec(L),
             preamble: []const u8,
             allocator: Allocator,
-            lock: std.Thread.RwLock,
+            lock: lock_impl.RwLock,
             values: MetricVec(L).HashMap(Value),
 
             pub const Value = struct {

--- a/src/gauge.zig
+++ b/src/gauge.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const lock_impl = @import("lock.zig");
 const Allocator = std.mem.Allocator;
 
 const m = @import("metric.zig");
@@ -148,7 +149,7 @@ pub fn GaugeVec(comptime V: type, comptime L: type) type {
             vec: MetricVec(L),
             preamble: []const u8,
             allocator: Allocator,
-            lock: std.Thread.RwLock,
+            lock: lock_impl.RwLock,
             values: MetricVec(L).HashMap(Value),
 
             const Value = struct {

--- a/src/histogram.zig
+++ b/src/histogram.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const lock_impl = @import("lock.zig");
 const Allocator = std.mem.Allocator;
 
 const m = @import("metric.zig");
@@ -178,7 +179,7 @@ pub fn HistogramVec(comptime V: type, comptime L: type, comptime upper_bounds: [
             vec: MetricVec(L),
             preamble: []const u8,
             allocator: Allocator,
-            lock: std.Thread.RwLock,
+            lock: lock_impl.RwLock,
             values: MetricVec(L).HashMap(Value),
             output_sum_prefix: []const u8,
             output_count_prefix: []const u8,
@@ -188,7 +189,7 @@ pub fn HistogramVec(comptime V: type, comptime L: type, comptime upper_bounds: [
             const Value = struct {
                 sum: V,
                 count: usize,
-                mutex: std.Thread.Mutex,
+                mutex: lock_impl.Mutex,
                 buckets: [upper_bounds.len]V,
                 // this gets glued to our output_bucket_prefixes
                 attributes: []const u8,

--- a/src/lock.zig
+++ b/src/lock.zig
@@ -1,0 +1,70 @@
+//! Simple spin-based synchronization primitives for Zig 0.16+.
+//! std.Thread.Mutex and std.Thread.RwLock were removed in 0.16;
+//! the new std.Io.Mutex/RwLock require an Io context which is too
+//! heavy a dependency for a metrics library.  These lightweight
+//! spin implementations cover the low-contention use-case well.
+
+const std = @import("std");
+
+/// A simple blocking mutex backed by an atomic boolean.
+pub const Mutex = struct {
+    state: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    pub const init: Mutex = .{};
+
+    pub fn lock(m: *Mutex) void {
+        while (true) {
+            // try to go from unlocked (false) -> locked (true)
+            if (m.state.cmpxchgWeak(false, true, .acquire, .monotonic) == null) return;
+            // spin
+            std.Thread.yield() catch {};
+        }
+    }
+
+    pub fn unlock(m: *Mutex) void {
+        m.state.store(false, .release);
+    }
+};
+
+/// A simple blocking readers-writer lock backed by an atomic i32.
+///
+/// Encoding:
+///   -1  = writer holds the lock
+///   >=0 = number of concurrent readers
+pub const RwLock = struct {
+    state: std.atomic.Value(i32) = std.atomic.Value(i32).init(0),
+
+    pub const init: RwLock = .{};
+
+    // --- exclusive (write) lock ---
+
+    pub fn lock(rw: *RwLock) void {
+        // Spin until we can go from 0 -> -1
+        while (true) {
+            if (rw.state.cmpxchgWeak(0, -1, .acquire, .monotonic) == null) return;
+            std.Thread.yield() catch {};
+        }
+    }
+
+    pub fn unlock(rw: *RwLock) void {
+        _ = rw.state.swap(0, .release);
+    }
+
+    // --- shared (read) lock ---
+
+    pub fn lockShared(rw: *RwLock) void {
+        while (true) {
+            const s = rw.state.load(.monotonic);
+            if (s >= 0) {
+                // try to add a reader
+                if (rw.state.cmpxchgWeak(s, s + 1, .acquire, .monotonic) == null) return;
+            }
+            // writer holds lock or CAS failed — spin
+            std.Thread.yield() catch {};
+        }
+    }
+
+    pub fn unlockShared(rw: *RwLock) void {
+        _ = rw.state.fetchSub(1, .release);
+    }
+};

--- a/src/metric.zig
+++ b/src/metric.zig
@@ -365,10 +365,7 @@ fn HashContext(comptime K: type) type {
             const V = @TypeOf(value);
             switch (@typeInfo(V)) {
                 .int => |int| switch (int.signedness) {
-                    .signed => hashValue(hasher, @as(@Type(.{ .int = .{
-                        .bits = int.bits,
-                        .signedness = .unsigned,
-                    } }), @bitCast(value))),
+                    .signed => hashValue(hasher, @as(@Int(.unsigned, int.bits), @bitCast(value))),
                     .unsigned => {
                         if (std.meta.hasUniqueRepresentation(V)) {
                             hasher.update(std.mem.asBytes(&value));

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -93,7 +93,7 @@ pub fn main() !void {
                 fail += 1;
                 Printer.status(.fail, "\n{s}\n\"{s}\" - {s}\n{s}\n", .{ BORDER, friendly_name, @errorName(err), BORDER });
                 if (@errorReturnTrace()) |trace| {
-                    std.debug.dumpStackTrace(trace.*);
+                    std.debug.dumpStackTrace(trace);
                 }
                 if (env.fail_first) {
                     break;
@@ -130,7 +130,7 @@ pub fn main() !void {
     Printer.fmt("\n", .{});
     try slowest.display();
     Printer.fmt("\n", .{});
-    std.posix.exit(if (fail == 0) 0 else 1);
+    std.process.exit(if (fail == 0) 0 else 1);
 }
 
 const Printer = struct {
@@ -159,16 +159,23 @@ const Status = enum {
 const SlowTracker = struct {
     const SlowestQueue = std.PriorityDequeue(TestInfo, void, compareTiming);
     max: usize,
+    allocator: Allocator,
     slowest: SlowestQueue,
-    timer: std.time.Timer,
+    start_ns: u64,
+
+    fn monoNs() u64 {
+        var ts: std.os.linux.timespec = undefined;
+        _ = std.os.linux.clock_gettime(std.os.linux.CLOCK.MONOTONIC, &ts);
+        return @as(u64, @intCast(ts.sec)) * 1_000_000_000 + @as(u64, @intCast(ts.nsec));
+    }
 
     fn init(allocator: Allocator, count: u32) SlowTracker {
-        const timer = std.time.Timer.start() catch @panic("failed to start timer");
-        var slowest = SlowestQueue.init(allocator, {});
-        slowest.ensureTotalCapacity(count) catch @panic("OOM");
+        var slowest = SlowestQueue.initContext({});
+        slowest.ensureTotalCapacity(allocator, count) catch @panic("OOM");
         return .{
+            .allocator = allocator,
             .max = count,
-            .timer = timer,
+            .start_ns = monoNs(),
             .slowest = slowest,
         };
     }
@@ -179,23 +186,22 @@ const SlowTracker = struct {
     };
 
     fn deinit(self: SlowTracker) void {
-        self.slowest.deinit();
+        self.slowest.deinit(self.allocator);
     }
 
     fn startTiming(self: *SlowTracker) void {
-        self.timer.reset();
+        self.start_ns = monoNs();
     }
 
     fn endTiming(self: *SlowTracker, test_name: []const u8) u64 {
-        var timer = self.timer;
-        const ns = timer.lap();
+        const ns = monoNs() - self.start_ns;
 
         var slowest = &self.slowest;
 
         if (slowest.count() < self.max) {
             // Capacity is fixed to the # of slow tests we want to track
             // If we've tracked fewer tests than this capacity, than always add
-            slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+            slowest.push(self.allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
             return ns;
         }
 
@@ -210,16 +216,18 @@ const SlowTracker = struct {
         }
 
         // the previous fastest of our slow tests, has been pushed off.
-        _ = slowest.removeMin();
-        slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+        _ = slowest.popMin();
+        slowest.push(self.allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
         return ns;
     }
 
     fn display(self: *SlowTracker) !void {
+        const alloc = self.allocator;
+        _ = alloc;
         var slowest = self.slowest;
         const count = slowest.count();
         Printer.fmt("Slowest {d} test{s}: \n", .{ count, if (count != 1) "s" else "" });
-        while (slowest.removeMinOrNull()) |info| {
+        while (slowest.popMin()) |info| {
             const ms = @as(f64, @floatFromInt(info.ns)) / 1_000_000.0;
             Printer.fmt("  {d:.2}ms\t{s}\n", .{ ms, info.name });
         }
@@ -251,14 +259,33 @@ const Env = struct {
     }
 
     fn readEnv(allocator: Allocator, key: []const u8) ?[]const u8 {
-        const v = std.process.getEnvVarOwned(allocator, key) catch |err| {
-            if (err == error.EnvironmentVariableNotFound) {
-                return null;
+        // Use raw Linux syscalls to read /proc/self/environ without libc dependency
+        const linux = std.os.linux;
+        const fd_raw = linux.open("/proc/self/environ", .{ .ACCMODE = .RDONLY }, 0);
+        if (linux.errno(fd_raw) != .SUCCESS) return null;
+        const fd: i32 = @intCast(fd_raw);
+        defer _ = linux.close(fd);
+
+        var buf: [64 * 1024]u8 = undefined;
+        var total: usize = 0;
+        while (total < buf.len) {
+            const n_raw = linux.read(fd, buf[total..].ptr, buf.len - total);
+            if (linux.errno(n_raw) != .SUCCESS) break;
+            const n: usize = @intCast(n_raw);
+            if (n == 0) break;
+            total += n;
+        }
+
+        var it = std.mem.splitScalar(u8, buf[0..total], 0);
+        while (it.next()) |entry| {
+            if (std.mem.startsWith(u8, entry, key)) {
+                const rest = entry[key.len..];
+                if (rest.len > 0 and rest[0] == '=') {
+                    return allocator.dupe(u8, rest[1..]) catch null;
+                }
             }
-            std.log.warn("failed to get env var {s} due to err {}", .{ key, err });
-            return null;
-        };
-        return v;
+        }
+        return null;
     }
 
     fn readEnvBool(allocator: Allocator, key: []const u8, deflt: bool) bool {


### PR DESCRIPTION
## Summary

Upgrades the library to compile and pass all tests with Zig 0.16 (dev build).

## Changes

### `src/lock.zig` (new)
- Added spin-based `RwLock` and `Mutex` primitives
- `std.Thread.RwLock` and `std.Thread.Mutex` were removed in 0.16 — they moved to `std.Io.RwLock`/`std.Io.Mutex` which require an `Io` context not suitable for a metrics library
- The new spin-based implementations use `std.atomic.Value` — correct for low-contention metrics workloads

### `src/metric.zig`
- `@Type(.{ .int = .{ .bits = N, .signedness = .unsigned } })` → `@Int(.unsigned, N)`
- `@Type` for integer construction was replaced by the `@Int` builtin in 0.16

### `src/counter.zig`, `src/gauge.zig`, `src/histogram.zig`
- Replace `std.Thread.RwLock` → `lock_impl.RwLock` (from new `lock.zig`)
- Replace `std.Thread.Mutex` → `lock_impl.Mutex`

### `test_runner.zig`
- `std.time.Timer` removed → use `std.os.linux.clock_gettime` directly
- `std.PriorityDequeue.init` → `initContext`; `add` → `push(allocator, ...)`; `removeMin` → `popMin`; `deinit` now takes allocator
- `std.process.getEnvVarOwned` removed → read `/proc/self/environ` via raw Linux syscalls
- `std.posix.exit` → `std.process.exit`
- Removed libc dependency

## Test results

```
37 of 37 tests passed
```

Tested against Zig 0.16.0-dev.2915+065c6e794.

🤖 Generated with AI assistance