### PR TITLE
chore: upgrade to Zig 0.16.0 (released)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,4 +3,5 @@
     .paths = .{""},
     .version = "0.0.0",
     .fingerprint = 0x228aaae778b8b15b,
+    .minimum_zig_version = "0.16.0",
 }

--- a/example/lib/metrics.zig
+++ b/example/lib/metrics.zig
@@ -36,11 +36,11 @@ pub fn latency(labels: LatencyLabel, value: f32) !void {
 	return metrics.latency.observe(labels, value);
 }
 
-pub fn initialize(allocator: Allocator, comptime opts: m.RegistryOpts) !void {
+pub fn initialize(allocator: Allocator, io: std.Io, comptime opts: m.RegistryOpts) !void {
 	metrics = .{
-		.hits = try Metrics.Hits.init(allocator, "lib_hits", .{}, opts),
+		.hits = try Metrics.Hits.init(allocator, io, "lib_hits", .{}, opts),
 		.active = Metrics.Active.init("lib_active", .{}, opts),
-		.latency = try Metrics.Latency.init(allocator, "lib_latency", .{}, opts),
+		.latency = try Metrics.Latency.init(allocator, io, "lib_latency", .{}, opts),
 	};
 }
 

--- a/example/main.zig
+++ b/example/main.zig
@@ -13,16 +13,16 @@ const m = @import("metrics");
 const lib = @import("lib/lib.zig");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
+    var debug_allocator: std.heap.DebugAllocator(.{}) = .{ .backing_allocator = std.heap.smp_allocator };
+    const allocator = debug_allocator.allocator();
 
-    var threaded = std.Io.Threaded.init_single_threaded;
+    var threaded: std.Io.Threaded = .init_single_threaded;
     const io = threaded.io();
 
     // The application initializes the metrics for all the libraries it wishes
     // to get metrics from. Optionally, the application can force a metric
     // name prefix and can exclude specific metrics
-    try lib.initializeMetrics(allocator, .{
+    try lib.initializeMetrics(allocator, io, .{
         .prefix = "", // default to ""
         .exclude = null, // defaults to null
     });

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -97,7 +97,7 @@ pub fn main() !void {
                 fail += 1;
                 Printer.status(.fail, "\n{s}\n\"{s}\" - {s}\n{s}\n", .{ BORDER, friendly_name, @errorName(err), BORDER });
                 if (@errorReturnTrace()) |trace| {
-                    std.debug.dumpStackTrace(trace);
+                    std.debug.dumpStackTrace(@ptrCast(trace));
                 }
                 if (env.fail_first) {
                     break;
@@ -184,7 +184,7 @@ const SlowTracker = struct {
         name: []const u8,
     };
 
-    fn deinit(self: SlowTracker, allocator: Allocator) void {
+    fn deinit(self: *SlowTracker, allocator: Allocator) void {
         self.slowest.deinit(allocator);
     }
 

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -97,7 +97,7 @@ pub fn main() !void {
                 fail += 1;
                 Printer.status(.fail, "\n{s}\n\"{s}\" - {s}\n{s}\n", .{ BORDER, friendly_name, @errorName(err), BORDER });
                 if (@errorReturnTrace()) |trace| {
-                    std.debug.dumpStackTrace(@ptrCast(trace));
+                    std.debug.dumpErrorReturnTrace(trace);
                 }
                 if (env.fail_first) {
                     break;


### PR DESCRIPTION
## Summary

Upgrades metrics.zig from Zig `0.16.0-dev.2960` to the official `0.16.0` release.

### Changes
- **example/main.zig**: Replace `GeneralPurposeAllocator` with `DebugAllocator` (GPA was removed in 0.16.0)
- **example/lib/metrics.zig**: Add missing `io` parameter to `initialize` function (matches the `init` signature added in dev branch)
- **test_runner.zig**: Fix `StackTrace` type mismatch (`builtin.StackTrace` vs `debug.StackTrace` split in 0.16.0)
- **test_runner.zig**: Fix `SlowTracker.deinit` to take `*SlowTracker` (const discard fix)
- **build.zig.zon**: Add `minimum_zig_version = "0.16.0"`